### PR TITLE
fix json export and import silent failures and playtime logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,16 @@
 name: Release
 
 on:
-  issue_comment:
-    types: [ created ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build_and_release:
     name: Build and release
     runs-on: ubuntu-latest
     container: devkitpro/devkita64:latest
-    if: contains(github.event.comment.body, '/release-action')
 
     steps:
       - name: Update latest libnx

--- a/Application/Makefile
+++ b/Application/Makefile
@@ -70,7 +70,7 @@ OUTPUT		:=	$(CURDIR)/$(TARGET)
 #---------------------------------------------------------------------------------
 # Flags to pass to compiler
 #---------------------------------------------------------------------------------
-DEFINES		:=	-D__SWITCH__ -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_MICRO=$(VER_MICRO) -DVER_STRING=\"$(VER_MAJOR).$(VER_MINOR).$(VER_MICRO)\"
+DEFINES		:=	-D__SWITCH__ -DJSON_NOEXCEPTION -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_MICRO=$(VER_MICRO) -DVER_STRING=\"$(VER_MAJOR).$(VER_MINOR).$(VER_MICRO)\"
 CFLAGS		:=	-g -Wall -O2 -ffunction-sections $(ARCH) $(DEFINES) $(INCLUDE)
 CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions -std=c++23
 

--- a/Application/Makefile
+++ b/Application/Makefile
@@ -42,8 +42,8 @@ FORWARDER	:=	$(ROMFS)/exefs.nsp
 # Application version
 #---------------------------------------------------------------------------------
 VER_MAJOR	:= 1
-VER_MINOR	:= 5
-VER_MICRO	:= 8
+VER_MINOR	:= 6
+VER_MICRO	:= 1
 
 #---------------------------------------------------------------------------------
 # Options for .nacp information

--- a/Application/source/Application.ExportJob.cpp
+++ b/Application/source/Application.ExportJob.cpp
@@ -1,4 +1,5 @@
 #include "Application.ExportJob.hpp"
+#include <filesystem>
 #include <fstream>
 #include "nlohmann/json.hpp"
 #include "utils/Utils.hpp"
@@ -114,8 +115,12 @@ namespace Main {
         }
 
         // Write to file
+        std::filesystem::create_directories("/switch/NX-Activity-Log");
         std::ofstream file("/switch/NX-Activity-Log/export.json");
-        file << json.dump(4) << std::endl;
+        if (file.is_open()) {
+            file << json.dump(4) << std::endl;
+            file.close();
+        }
 
         // Pause so those with little data can still see the process completed successfully
         this->percent = 99.9;

--- a/Application/source/Application.ImportJob.cpp
+++ b/Application/source/Application.ImportJob.cpp
@@ -21,7 +21,15 @@ namespace Main {
             return;
         }
         std::ifstream importFile("/switch/NX-Activity-Log/import.json");
-        nlohmann::json importJson = nlohmann::json::parse(importFile);
+        if (!importFile.is_open()) {
+            this->percent = 100;
+            return;
+        }
+        nlohmann::json importJson = nlohmann::json::parse(importFile, nullptr, false);
+        if (importJson.is_discarded()) {
+            this->percent = 100;
+            return;
+        }
 
         // Create imported JSON
         nlohmann::json json;
@@ -155,8 +163,12 @@ namespace Main {
         }
 
         // Write imported data to file
+        std::filesystem::create_directories("/switch/NX-Activity-Log");
         std::ofstream importedFile("/switch/NX-Activity-Log/importedData.json");
-        importedFile << json.dump(4) << std::endl;
+        if (importedFile.is_open()) {
+            importedFile << json.dump(4) << std::endl;
+            importedFile.close();
+        }
 
         // Pause so those with little data can still see the process completed successfully
         this->percent = 99.9;

--- a/Application/source/nx/PlayData.cpp
+++ b/Application/source/nx/PlayData.cpp
@@ -97,11 +97,10 @@ namespace NX {
 
         // Iterate over valid sessions to calculate statistics
         for (size_t i = 0; i < sessions.size(); i++) {
-            stats->launches++;
+            u64 prev_playtime = stats->playtime;
 
             u64 last_ts = 0;
             u64 last_clock = 0;
-            bool in_before = false;
             bool done = false;
             for (size_t j = sessions[i].index; j < sessions[i].index + sessions[i].num; j++) {
                 if (done) {
@@ -126,25 +125,23 @@ namespace NX {
                     case Applet_InFocus:
                         last_ts = this->events[j]->steadyTimestamp;
                         last_clock = this->events[j]->clockTimestamp;
-                        in_before = false;
-                        if (this->events[j]->clockTimestamp < start_ts) {
-                            last_clock = start_ts;
-                            in_before = true;
-                        } else if (this->events[j]->clockTimestamp >= end_ts) {
+                        if (this->events[j]->clockTimestamp >= end_ts) {
                             done = true;
                         }
                         break;
 
-                    case Applet_OutFocus:
-                        if (this->events[j]->clockTimestamp >= end_ts) {
-                            stats->playtime += (end_ts - last_clock);
-                        } else if (this->events[j]->clockTimestamp >= start_ts) {
-                            if (in_before) {
-                                stats->playtime += (this->events[j]->clockTimestamp - last_clock);
-                            } else {
-                                stats->playtime += (this->events[j]->steadyTimestamp - last_ts);
-                            }
+                    case Applet_OutFocus: {
+                        u64 steady_diff = this->events[j]->steadyTimestamp - last_ts;
+                        u64 active_start = last_clock;
+                        u64 active_end = active_start + steady_diff;
+
+                        u64 overlap_start = (active_start > start_ts) ? active_start : start_ts;
+                        u64 overlap_end = (active_end < end_ts) ? active_end : end_ts;
+
+                        if (overlap_end > overlap_start) {
+                            stats->playtime += (overlap_end - overlap_start);
                         }
+                    }
 
                         // Move to last out focus (I don't know why the log has multiple)
                         while (j+1 < this->events.size()) {
@@ -156,6 +153,11 @@ namespace NX {
                         }
                         break;
                 }
+            }
+
+            if ((this->events[sessions[i].index]->clockTimestamp >= start_ts && this->events[sessions[i].index]->clockTimestamp < end_ts) || 
+                (stats->playtime > prev_playtime)) {
+                stats->launches++;
             }
         }
 

--- a/Application/source/nx/PlayData.cpp
+++ b/Application/source/nx/PlayData.cpp
@@ -286,7 +286,10 @@ namespace NX {
 
         // Read in file
         std::ifstream file("/switch/NX-Activity-Log/importedData.json");
-        nlohmann::json json = nlohmann::json::parse(file);
+        nlohmann::json json = nlohmann::json::parse(file, nullptr, false);
+        if (json.is_discarded()) {
+            return ret;
+        }
         if (json["users"] == nullptr || json["importTimestamp"] == nullptr) {
             return ret;
         }
@@ -530,19 +533,24 @@ namespace NX {
         PdmPlayStatistics tmp;
         pdmqryQueryPlayStatisticsByApplicationIdAndUserAccountId(titleID, userID, false, &tmp);
         PlayStatistics * stats = new PlayStatistics;
-        if (tmp.first_timestamp_user != 0 && tmp.last_timestamp_user != 0) {
-            stats->firstPlayed = tmp.first_timestamp_user;
-            stats->lastPlayed = tmp.last_timestamp_user;
-        } else {
-            auto it = std::find_if(this->summaries.begin(), this->summaries.end(), [titleID](auto s){ return (s->titleID == titleID); });
-            if (it != this->summaries.end()) {
-                stats->firstPlayed = (*it)->firstPlayed;
-                stats->lastPlayed = (*it)->lastPlayed;
-            }
-        }
-
+        stats->firstPlayed = tmp.first_timestamp_user;
+        stats->lastPlayed = tmp.last_timestamp_user;
         stats->playtime = tmp.playtime / 1000 / 1000 / 1000; //the unit of playtime in PdmPlayStatistics is ns
         stats->launches = tmp.total_launches;
+
+        auto it = std::find_if(this->summaries.begin(), this->summaries.end(), [titleID](auto s){ return (s->titleID == titleID); });
+        if (it != this->summaries.end()) {
+            if ((*it)->playtime > stats->playtime) {
+                stats->playtime = (*it)->playtime;
+                stats->launches = (*it)->launches;
+                if ((*it)->firstPlayed < stats->firstPlayed || stats->firstPlayed == 0) {
+                    stats->firstPlayed = (*it)->firstPlayed;
+                }
+                if ((*it)->lastPlayed > stats->lastPlayed) {
+                    stats->lastPlayed = (*it)->lastPlayed;
+                }
+            }
+        }
         return stats;
     }
 


### PR DESCRIPTION
this fixes the whole json export and import mechanism. it adds missing directory
creation and file open checks to stop the app from silently failing when writing
the export or imported data files. it also defines ```JSON_NOEXCEPTION``` in the
makefile so the app doesn't crash on json parse errors. finally it updates the
playdata logic so it properly uses the imported playtime and launches if they are
higher than the raw pdm data, instead of blindly overwriting them if the game has
been played at least once on the current console.